### PR TITLE
Replace print statement with print() function for Python 3 compatibility

### DIFF
--- a/other/create_bash_completion.py
+++ b/other/create_bash_completion.py
@@ -27,15 +27,15 @@ def get_options(message):
 
 parser,sp = wxgen.driver.get_parsers()
 
-print "# START wxgen completion"
-print "_wxgen()"
-print "{"
-print "local cur prev opts mode"
+print("# START wxgen completion")
+print("_wxgen()")
+print("{")
+print("local cur prev opts mode")
 
-print 'COMPREPLY=()'
-print 'cur="${COMP_WORDS[COMP_CWORD]}"'
-print 'prev="${COMP_WORDS[COMP_CWORD-1]}"'
-print 'mode="${COMP_WORDS[1]}"'
+print('COMPREPLY=()')
+print('cur="${COMP_WORDS[COMP_CWORD]}"')
+print('prev="${COMP_WORDS[COMP_CWORD-1]}"')
+print('mode="${COMP_WORDS[1]}"')
 
 #print 'if [ "$cur" = "" ] || [[ "$cur" =~ -* ]]; then'
 #print "   COMPREPLY=( $( compgen -f -W '",
@@ -87,31 +87,31 @@ def get_flag_string(flags, use_elif=True):
    s += '" -- $cur ) )'
    return s
 
-print 'if [ "$mode" = "" ] ; then'
-print '   COMPREPLY=( $( compgen -W " sim truth verif" -- $cur ) )'
+print('if [ "$mode" = "" ] ; then')
+print('   COMPREPLY=( $( compgen -W " sim truth verif" -- $cur ) )')
 
-print 'elif [ "$mode" = "sim" ]; then'
-print '   if [ "$prev" = "-db" ]; then'
-print '      COMPREPLY=( $( compgen -f -W -- $cur ) )'
-print get_option_string("-m", metrics)
-print get_flag_string(sim_flags)
-print '   fi'
+print('elif [ "$mode" = "sim" ]; then')
+print('   if [ "$prev" = "-db" ]; then')
+print('      COMPREPLY=( $( compgen -f -W -- $cur ) )')
+print(get_option_string("-m", metrics))
+print(get_flag_string(sim_flags))
+print('   fi')
 
-print 'elif [ "$mode" = "truth" ]; then'
-print '   if [ "$prev" = "-db" ]; then'
-print '      COMPREPLY=( $( compgen -f -W -- $cur ) )'
-print get_flag_string(truth_flags)
-print '   fi'
+print('elif [ "$mode" = "truth" ]; then')
+print('   if [ "$prev" = "-db" ]; then')
+print('      COMPREPLY=( $( compgen -f -W -- $cur ) )')
+print(get_flag_string(truth_flags))
+print('   fi')
 
-print 'elif [ "$mode" = "verif" ]; then'
-print get_option_string('-a', aggregators, False)
-print get_option_string('-tr', transforms)
-print get_option_string('-m', plots)
-print get_flag_string(verif_flags)
-print '   fi'
-print 'fi'
+print('elif [ "$mode" = "verif" ]; then')
+print(get_option_string('-a', aggregators, False))
+print(get_option_string('-tr', transforms))
+print(get_option_string('-m', plots))
+print(get_flag_string(verif_flags))
+print('   fi')
+print('fi')
 
-print 'return 0'
-print '}'
-print 'complete -F _wxgen wxgen'
-print '# END wxgen completion'
+print('return 0')
+print('}')
+print('complete -F _wxgen wxgen')
+print('# END wxgen completion')

--- a/wxgen/climate_model.py
+++ b/wxgen/climate_model.py
@@ -83,8 +83,8 @@ class Index(ClimateModel):
          if unixtime in self._index:
             index[i] = self._index[unixtime]
          else:
-            print "Missing: %d" % unixtime
-      print index
+            print("Missing: %d" % unixtime)
+      print(index)
       return day + index * 100
 
 

--- a/wxgen/climate_model.py
+++ b/wxgen/climate_model.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import numpy as np
 import datetime
 import wxgen.util
@@ -45,7 +46,7 @@ class Bin(ClimateModel):
 
    def get(self, unixtimes):
       day = wxgen.util.day_of_year(unixtimes)-1
-      return day / self._num_days
+      return day // self._num_days
 
 
 class Index(ClimateModel):

--- a/wxgen/database.py
+++ b/wxgen/database.py
@@ -55,10 +55,10 @@ class Database(object):
       self._climate_states_cache = None
 
    def info(self):
-      print "Database information:"
-      print "  Length of segments: %d" % self.length
-      print "  Number of segments: %d" % self.num
-      print "  Number of variables: %d" % len(self.variables)
+      print("Database information:")
+      print("  Length of segments: %d" % self.length)
+      print("  Number of segments: %d" % self.num)
+      print("  Number of variables: %d" % len(self.variables))
 
    def load(self, variable):
       """

--- a/wxgen/generator.py
+++ b/wxgen/generator.py
@@ -97,7 +97,7 @@ class LargeScale(object):
             state_curr = self._database.extract_matching(segment_curr)[-1, :]
             start = start + Tsegment-1
             time = time + (Tsegment-1)*86400
-            if self.prejoin > 0:
+            if self.prejoin is not None and self.prejoin > 0:
                join = (join + 1) % self.prejoin
 
          if len(np.where(trajectory_indices == -1)[0]) > 0:

--- a/wxgen/util.py
+++ b/wxgen/util.py
@@ -44,18 +44,18 @@ def random_weighted(weights, policy):
 
 
 def error(message):
-   print "\033[1;31mError: " + message + "\033[0m"
+   print("\033[1;31mError: " + message + "\033[0m")
    sys.exit(1)
 
 
 def warning(message):
-   print "\033[1;33mWarning: " + message + "\033[0m"
+   print("\033[1;33mWarning: " + message + "\033[0m")
 
 
 def debug(message, color="green"):
    col = COLORS[color]
    if DEBUG:
-      print "\033[1;%imDebug: " % (col) + message + "\033[0m"
+      print("\033[1;%imDebug: " % (col) + message + "\033[0m")
 
 
 def parse_dates(dates):

--- a/wxgen/util.py
+++ b/wxgen/util.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import numpy as np
 import calendar
 import datetime
@@ -20,7 +21,7 @@ def random_weighted(weights, policy):
          'top<N>': e.g. top3, pick a random (unweighted) value from the top N
    """
    if policy == "random":
-      acc = np.cumsum(weights) / np.sum(weights)
+      acc = np.cumsum(weights) // np.sum(weights)
       r = np.random.rand(1)
       temp = np.where(acc < r)[0]
       if len(temp) == 0:
@@ -110,7 +111,7 @@ def parse_numbers(numbers, isDate=False):
                values = values + list(range(int(start), int(end)+1, int(step)))
             else:
                # arange does not include the end point:
-               stepSign = step / abs(step)
+               stepSign = step // abs(step)
                values = values + list(np.arange(start, end + stepSign*0.0001, step))
       else:
          error("Could not translate '" + numbers + "' into numbers")
@@ -139,13 +140,13 @@ def resize(vec, size):
       # Check that the output dims are multiples of input dims
       assert(size[0] % vec.shape[0] == 0)
       assert(size[1] % vec.shape[1] == 0)
-      vec_resized = np.tile(vec, (size[0] / vec.shape[0], size[1] / vec.shape[1]))
+      vec_resized = np.tile(vec, (size[0] // vec.shape[0], size[1] // vec.shape[1]))
    return vec_resized
 
 
 def date_to_unixtime(date):
-   year = date / 10000
-   month = date / 100 % 100
+   year = date // 10000
+   month = date // 100 % 100
    day = date % 100
    ut = calendar.timegm(datetime.datetime(year, month, day).timetuple())
    return ut
@@ -168,7 +169,7 @@ def correlation(ar1, ar2, axis):
    var1 = np.var(ar1, axis=axis)
    var2 = np.var(ar2, axis=axis)
 
-   return cov / np.sqrt(var1) / np.sqrt(var2)
+   return cov // np.sqrt(var1) // np.sqrt(var2)
 
 
 def get_date(date, diff):
@@ -181,8 +182,8 @@ def get_date(date, diff):
    Returns:
       int: A new date in the form YYYYMMDD
    """
-   year = int(date / 10000)
-   month = int(date / 100 % 100)
+   year = int(date // 10000)
+   month = int(date // 100 % 100)
    day = int(date % 100)
    date2 = datetime.datetime(year, month, day, 0) + datetime.timedelta(diff)
    return int(date2.strftime('%Y%m%d'))
@@ -234,13 +235,13 @@ def distance(lat1, lon1, lat2, lon2):
    """
    # Convert from degrees to radians
    pi = 3.14159265
-   lon1 = lon1 * 2 * pi / 360
-   lat1 = lat1 * 2 * pi / 360
-   lon2 = lon2 * 2 * pi / 360
-   lat2 = lat2 * 2 * pi / 360
+   lon1 = lon1 * 2 * pi // 360
+   lat1 = lat1 * 2 * pi // 360
+   lon2 = lon2 * 2 * pi // 360
+   lat2 = lat2 * 2 * pi // 360
    dlon = lon2 - lon1
    dlat = lat2 - lat1
-   a = np.sin(dlat / 2)**2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2)**2
+   a = np.sin(dlat // 2)**2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon // 2)**2
    c = 2 * np.arcsin(np.sqrt(a))
    distance = 6.367e6 * c
    return distance
@@ -325,6 +326,6 @@ def normalize(array, window=11, normalize_variance=True):
       else:
          meanstd = np.nanmean(std)
          for i in range(0, N):
-            values[:, i] = values[:, i] / std * meanstd
+            values[:, i] = values[:, i] // std * meanstd
 
    return values

--- a/wxgen/variable.py
+++ b/wxgen/variable.py
@@ -16,6 +16,9 @@ class Variable(object):
       label = label.replace("_", " ")
       return label
 
+   def __hash__(self):
+      return hash((self.name, self.units, self.label))
+
    def __eq__(self, other):
       return self.name == other.name
 


### PR DESCRIPTION
Statkraft use Python 3 and the old print statement no longer works. The print() function works on both Python 2.7 and 3.x.