### PR TITLE
Futher changes to python 3 compatibility

### DIFF
--- a/wxgen/database.py
+++ b/wxgen/database.py
@@ -70,7 +70,7 @@ class Database(object):
 
          if len(self._data_cache) > 0:
             # Check if we need to remove data from cache
-            akey = self._data_cache.keys()[0]
+            akey = list(self._data_cache.keys())[0]
             bytes_per_value = 4
             size_per_key = np.product(self._data_cache[akey].shape) * bytes_per_value
             next_size = float(len(self._data_cache) + 1) * size_per_key

--- a/wxgen/database.py
+++ b/wxgen/database.py
@@ -78,7 +78,7 @@ class Database(object):
             if self.mem is not None and next_size_gb > self.mem:
                # remove from cache
                I = np.random.randint(len(self._data_cache))
-               rmkey = self._data_cache.keys()[I]
+               rmkey = list(self._data_cache.keys())[I]
                self._data_cache.pop(rmkey)
                wxgen.util.warning("Cache full (%2.1fGB): Removing member '%s' from cache" % (next_size_gb, rmkey.name))
 

--- a/wxgen/tests/integration_test.py
+++ b/wxgen/tests/integration_test.py
@@ -4,6 +4,7 @@ import numpy as np
 import tempfile
 import netCDF4
 import wxgen.driver
+import time
 np.seterr('raise')
 
 
@@ -110,9 +111,11 @@ class IntegrationTest(unittest.TestCase):
       self.run_with_image("wxgen verif %s %s -m timeseries" % (sim_filename, truth_filename))
       self.run_with_image("wxgen verif %s %s -m variance" % (sim_filename, truth_filename))
 
+      time.sleep(1)
+
       for filename in [sim_filename, truth_filename]:
          self.remove(filename)
-
+           
 
 if __name__ == '__main__':
    unittest.main()

--- a/wxgen/util.py
+++ b/wxgen/util.py
@@ -21,7 +21,7 @@ def random_weighted(weights, policy):
          'top<N>': e.g. top3, pick a random (unweighted) value from the top N
    """
    if policy == "random":
-      acc = np.cumsum(weights) // np.sum(weights)
+      acc = np.cumsum(weights) / np.sum(weights)
       r = np.random.rand(1)
       temp = np.where(acc < r)[0]
       if len(temp) == 0:
@@ -111,7 +111,7 @@ def parse_numbers(numbers, isDate=False):
                values = values + list(range(int(start), int(end)+1, int(step)))
             else:
                # arange does not include the end point:
-               stepSign = step // abs(step)
+               stepSign = step / abs(step)
                values = values + list(np.arange(start, end + stepSign*0.0001, step))
       else:
          error("Could not translate '" + numbers + "' into numbers")
@@ -140,7 +140,7 @@ def resize(vec, size):
       # Check that the output dims are multiples of input dims
       assert(size[0] % vec.shape[0] == 0)
       assert(size[1] % vec.shape[1] == 0)
-      vec_resized = np.tile(vec, (size[0] // vec.shape[0], size[1] // vec.shape[1]))
+      vec_resized = np.tile(vec, (size[0] / vec.shape[0], size[1] / vec.shape[1]))
    return vec_resized
 
 
@@ -169,7 +169,7 @@ def correlation(ar1, ar2, axis):
    var1 = np.var(ar1, axis=axis)
    var2 = np.var(ar2, axis=axis)
 
-   return cov // np.sqrt(var1) // np.sqrt(var2)
+   return cov / np.sqrt(var1) / np.sqrt(var2)
 
 
 def get_date(date, diff):
@@ -326,6 +326,6 @@ def normalize(array, window=11, normalize_variance=True):
       else:
          meanstd = np.nanmean(std)
          for i in range(0, N):
-            values[:, i] = values[:, i] // std * meanstd
+            values[:, i] = values[:, i] / std * meanstd
 
    return values

--- a/wxgen/util.py
+++ b/wxgen/util.py
@@ -235,13 +235,13 @@ def distance(lat1, lon1, lat2, lon2):
    """
    # Convert from degrees to radians
    pi = 3.14159265
-   lon1 = lon1 * 2 * pi // 360
-   lat1 = lat1 * 2 * pi // 360
-   lon2 = lon2 * 2 * pi // 360
-   lat2 = lat2 * 2 * pi // 360
+   lon1 = lon1 * 2 * pi / 360
+   lat1 = lat1 * 2 * pi / 360
+   lon2 = lon2 * 2 * pi / 360
+   lat2 = lat2 * 2 * pi / 360
    dlon = lon2 - lon1
    dlat = lat2 - lat1
-   a = np.sin(dlat // 2)**2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon // 2)**2
+   a = np.sin(dlat / 2)**2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2)**2
    c = 2 * np.arcsin(np.sqrt(a))
    distance = 6.367e6 * c
    return distance


### PR DESCRIPTION
Imported division from __future__, added floor division (//) where it looks like integer i expected from floats being divided by old division. 

Made object Variable hashable so that it can still be used as a dictionary key in py3. Added list() around places where dict.keys() is directly indexed (keys.() returns generator in py3).

Changed one instance where it tests variable > 0, where variable can also be None, to check for not None and > 0.

All changes should work the same in both Python 2 and 3.

Was able to successfully run a full simulation with these changes in a Python 3.5.2 environment.